### PR TITLE
Feature/presigned cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ next-env.d.ts
 __pycache__/
 venv
 /generated/prisma
+
+certificates

--- a/app/(front-end)/components/UploadForm.tsx
+++ b/app/(front-end)/components/UploadForm.tsx
@@ -24,6 +24,12 @@ export function UploadForm() {
       return;
     }
 
+    // MIMEタイプチェック
+    if (file.type !== "video/mp4") {
+      alert("mp4動画のみアップロード可能です");
+      return;
+    }
+
     setUploading(true);
     setMessage("");
     setUploadProgress(0);
@@ -97,7 +103,7 @@ export function UploadForm() {
             type="file"
             name="file"
             id="file"
-            accept="video/*"
+            accept="video/mp4"
             disabled={uploading}
             className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 disabled:opacity-50"
           />

--- a/app/(front-end)/components/UploadForm.tsx
+++ b/app/(front-end)/components/UploadForm.tsx
@@ -59,7 +59,7 @@ export function UploadForm() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          filePath: fileName || file.name,
+          filePath: fileName,
         }),
       });
 

--- a/app/(front-end)/components/videoList.tsx
+++ b/app/(front-end)/components/videoList.tsx
@@ -1,40 +1,71 @@
 "use client";
 
 import { Video } from "@/generated/prisma";
-import React, { useEffect } from "react";
-import ReactPlayer from "react-player";
+import React, { useEffect, useRef, useState } from "react";
+import Hls from "hls.js";
 
-const videoList = ({ videos }: { videos: Video[] }) => {
-  if (!videos || videos.length === 0) {
-    return <p className="text-gray-500">No videos available</p>;
-  }
+const VideoList = ({ videos }: { videos: Video[] }) => {
+  const [cookieSet, setCookieSet] = useState(false);
+  const videoRefs = useRef<Record<string, HTMLVideoElement | null>>({});
 
   useEffect(() => {
     const setCookie = async () => {
       const res = await fetch("/api/video/presigned_cookie", {
         method: "GET",
-        credentials: "include",
+        credentials: "include", // Cookie をブラウザに保存させる
       });
       if (!res.ok) {
         console.error("Failed to set presigned cookie");
+        return;
       }
+      setCookieSet(true);
     };
     setCookie();
   }, []);
+
+  useEffect(() => {
+    if (!cookieSet || !videos) return;
+
+    videos.forEach((video) => {
+      const videoElement = videoRefs.current[video.id];
+      if (videoElement && Hls.isSupported()) {
+        const hls = new Hls({
+          debug: true,
+          xhrSetup: (xhr, url) => {
+            xhr.withCredentials = true; // Cookie を CloudFront に送信
+          },
+        });
+        const videoSrc = `https://static.ami-works.com/users/${video.userId}/m3u8/${video.filePath}/${video.filePath}.m3u8`;
+        hls.loadSource(videoSrc);
+        hls.attachMedia(videoElement);
+      } else if (
+        videoElement &&
+        videoElement.canPlayType("application/vnd.apple.mpegurl")
+      ) {
+        // Safariなど、ネイティブHLS対応ブラウザ用
+        videoElement.src = `https://static.ami-works.com/users/${video.userId}/m3u8/${video.filePath}/${video.filePath}.m3u8`;
+      }
+    });
+  }, [cookieSet, videos]);
+
+  if (!videos || videos.length === 0) {
+    return <p className="text-gray-500">No videos available</p>;
+  }
 
   return (
     <div>
       {videos.map((video: Video) => (
         <div key={video.id} className="mb-4">
           <h3 className="text-lg font-semibold">{video.filePath}</h3>
-          <ReactPlayer
-            controls={true}
-            playing={true}
-            volume={0}
-            muted={true}
+          <video
+            ref={(el) => {
+              videoRefs.current[video.id] = el;
+            }}
+            controls
+            muted
             width="100%"
             height="100%"
-            src={`https://d1bn71d3v93is3.cloudfront.net/users/${video.userId}/m3u8/${video.filePath}/${video.filePath}.m3u8`}
+            style={{ backgroundColor: "black" }}
           />
           <p className="text-sm text-gray-500">
             Uploaded by User ID: {video.userId} on{" "}
@@ -46,4 +77,4 @@ const videoList = ({ videos }: { videos: Video[] }) => {
   );
 };
 
-export default videoList;
+export default VideoList;

--- a/app/(front-end)/components/videoList.tsx
+++ b/app/(front-end)/components/videoList.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Video } from "@/generated/prisma";
+import React, { useEffect } from "react";
+import ReactPlayer from "react-player";
+
+const videoList = ({ videos }: { videos: Video[] }) => {
+  if (!videos || videos.length === 0) {
+    return <p className="text-gray-500">No videos available</p>;
+  }
+
+  useEffect(() => {
+    const setCookie = async () => {
+      const res = await fetch("/api/video/presigned_cookie", {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        console.error("Failed to set presigned cookie");
+      }
+    };
+    setCookie();
+  }, []);
+
+  return (
+    <div>
+      {videos.map((video: Video) => (
+        <div key={video.id} className="mb-4">
+          <h3 className="text-lg font-semibold">{video.filePath}</h3>
+          <ReactPlayer
+            controls={true}
+            playing={true}
+            volume={0}
+            muted={true}
+            width="100%"
+            height="100%"
+            src={`https://d1bn71d3v93is3.cloudfront.net/users/${video.userId}/m3u8/${video.filePath}/${video.filePath}.m3u8`}
+          />
+          <p className="text-sm text-gray-500">
+            Uploaded by User ID: {video.userId} on{" "}
+            {new Date(video.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default videoList;

--- a/app/(front-end)/dashboard/page.tsx
+++ b/app/(front-end)/dashboard/page.tsx
@@ -1,16 +1,24 @@
-import React from "react";
-
 import { auth } from "@/auth";
 import { UploadForm } from "../components/UploadForm";
+import VideoList from "../components/videoList";
+import prisma from "@/lib/prisma";
 
 export default async function Page() {
   const session = await auth();
-  if (!session) return <div>Not authenticated</div>;
+  if (!session?.user) return <div>Not authenticated</div>;
+
+  // 動画の取得
+  const videos = await prisma.video.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "desc" },
+  });
 
   return (
-    <div>
-      <pre>{JSON.stringify(session, null, 2)}</pre>
+    <div className="container mx-auto p-4">
       <UploadForm />
+      <div className="flex flex-col items-center mt-8">
+        <VideoList videos={videos} />
+      </div>
     </div>
   );
 }

--- a/app/(front-end)/page.tsx
+++ b/app/(front-end)/page.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <main className="pt-5">
+    <main className="pt-4">
       <div className="max-w-[85rem] mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid md:grid-cols-2 gap-4 md:gap-8 xl:gap-20 md:items-center">
           <div>

--- a/app/api/video/presigned_cookie/route.ts
+++ b/app/api/video/presigned_cookie/route.ts
@@ -1,0 +1,40 @@
+// app/api/set-cookie/route.ts
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { NextAuthRequest } from "next-auth";
+import { createPresignedCookie } from "@/lib/cookie";
+
+export const GET = auth(async (request: NextAuthRequest) => {
+  const userid = request.auth?.user?.id;
+  if (!userid) {
+    return new NextResponse(JSON.stringify({ error: "User ID is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  try {
+    const cookies = createPresignedCookie(userid);
+
+    const res = NextResponse.json({ ok: true });
+
+    Object.entries(cookies).forEach(([name, value]) => {
+      res.cookies.set(name, value, {
+        httpOnly: true,
+        secure: true,
+        path: "/", // CloudFront URL に合致するように設定
+        sameSite: "strict",
+      });
+    });
+
+    return res;
+  } catch (error) {
+    console.error("Error setting cookies:", error);
+    return new NextResponse(
+      JSON.stringify({ error: "Failed to set cookies" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+});

--- a/app/api/video/presigned_cookie/route.ts
+++ b/app/api/video/presigned_cookie/route.ts
@@ -19,10 +19,11 @@ export const GET = auth(async (request: NextAuthRequest) => {
 
     Object.entries(cookies).forEach(([name, value]) => {
       res.cookies.set(name, value, {
+        domain: ".ami-works.com", // CloudFrontのドメインに合わせる
         httpOnly: true,
         secure: true,
         path: "/", // CloudFront URL に合致するように設定
-        sameSite: "strict",
+        sameSite: "none",
       });
     });
 

--- a/app/api/video/presigned_url/route.ts
+++ b/app/api/video/presigned_url/route.ts
@@ -82,7 +82,7 @@ export const POST = auth(async (request: NextAuthRequest) => {
 
     const presignedUrl = await createPostPresignedUrl({
       bucket: process.env.AWS_S3_VIDEO_BUCKET!,
-      key: `users/${request.auth?.user?.id}/${uniqueFileName}`,
+      key: `users/${request.auth?.user?.id}/uploads/${uniqueFileName}`,
     });
 
     return new NextResponse(

--- a/app/api/video/route.ts
+++ b/app/api/video/route.ts
@@ -4,6 +4,20 @@ import { videoSchema } from "@/schema/schema";
 import { NextAuthRequest } from "next-auth";
 import { NextResponse } from "next/server";
 
+export const GET = auth(async (request: NextAuthRequest) => {
+  const userId = request.auth?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const videos = await prisma.video.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(videos);
+});
+
 export const POST = auth(async (request: NextAuthRequest) => {
   try {
     const userId = request.auth?.user?.id;

--- a/app/api/video/route.ts
+++ b/app/api/video/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { videoSchema } from "@/schema/schema";
 import { NextAuthRequest } from "next-auth";
 import { NextResponse } from "next/server";
+import path from "path";
 
 export const GET = auth(async (request: NextAuthRequest) => {
   const userId = request.auth?.user?.id;
@@ -48,9 +49,21 @@ export const POST = auth(async (request: NextAuthRequest) => {
 
     const { filePath } = parsedBody.data;
 
+    if (!filePath) {
+      return new NextResponse(
+        JSON.stringify({ error: "File path is required" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+    // 拡張子を除いたファイル名を取得
+    const nameWithoutExt = path.parse(filePath).name;
+
     const video = await prisma.video.create({
       data: {
-        filePath: filePath,
+        filePath: nameWithoutExt,
         userId: userId,
       },
     });

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -1,0 +1,36 @@
+import { getSignedCookies } from "@aws-sdk/cloudfront-signer";
+import fs from "fs";
+import path from "path";
+
+export const createPresignedCookie = (userid: string) => {
+  const cloudfrontDistributionDomain = "https://d1bn71d3v93is3.cloudfront.net";
+  const url = `${cloudfrontDistributionDomain}/users/${userid}/m3u8/*`;
+  const privateKey = fs.readFileSync(path.resolve("private_key.pem"), "utf-8");
+  const keyPairId = "3c7ef49b-e4cf-4ca2-8148-bf2a061205a1";
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
+  const epochTime = Math.round(tomorrow.getTime() / 1000);
+
+  const policy = {
+    Statement: [
+      {
+        Resource: url,
+        Condition: {
+          DateLessThan: {
+            "AWS:EpochTime": epochTime, // time in seconds
+          },
+        },
+      },
+    ],
+  };
+
+  const policyString = JSON.stringify(policy);
+
+  const cookies = getSignedCookies({
+    keyPairId,
+    privateKey,
+    policy: policyString,
+  });
+  return cookies;
+};

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -3,10 +3,10 @@ import fs from "fs";
 import path from "path";
 
 export const createPresignedCookie = (userid: string) => {
-  const cloudfrontDistributionDomain = "https://d1bn71d3v93is3.cloudfront.net";
+  const cloudfrontDistributionDomain = "https://static.ami-works.com";
   const url = `${cloudfrontDistributionDomain}/users/${userid}/m3u8/*`;
   const privateKey = fs.readFileSync(path.resolve("private_key.pem"), "utf-8");
-  const keyPairId = "3c7ef49b-e4cf-4ca2-8148-bf2a061205a1";
+  const keyPairId = "K2DTJW2OP7KKU8";
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
   tomorrow.setHours(0, 0, 0, 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "concurrently": "^9.0.1",
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.4",
+        "hls.js": "^1.6.7",
         "lucide-react": "^0.513.0",
         "next": "^15.3.3",
         "next-auth": "^5.0.0-beta.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@auth/prisma-adapter": "^2.9.1",
         "@aws-sdk/client-s3": "^3.842.0",
+        "@aws-sdk/cloudfront-signer": "^3.858.0",
         "@aws-sdk/s3-request-presigner": "^3.842.0",
         "@prisma/client": "^6.9.0",
         "@prisma/extension-accelerate": "^2.0.1",
@@ -21,6 +22,7 @@
         "@types/react": "18.3.8",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.20",
+        "base64url": "^3.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
@@ -32,6 +34,7 @@
         "postcss": "^8.4.47",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-player": "^3.3.1",
         "tailwind-merge": "^3.3.0",
         "tailwindcss": "3.4.12",
         "tailwindcss-animate": "^1.0.7",
@@ -410,6 +413,19 @@
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
         "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/cloudfront-signer": {
+      "version": "3.858.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/cloudfront-signer/-/cloudfront-signer-3.858.0.tgz",
+      "integrity": "sha512-RXPcdJ/avC+VQtx3e1tno5y+pFW8RzOZLGqqko93IF9AJKps+RweAnrpQXh31ZfyaVTppr7KRjGCb0QfNamcAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/url-parser": "^4.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1658,6 +1674,74 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
+      "license": "MIT",
+      "dependencies": {
+        "mux-embed": "5.9.0"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.5.1.tgz",
+      "integrity": "sha512-PSi3mPb4LrEh4i3xUdodaEvMrbbpKbL2yaewRjsqBr3PFb+hd/Dp1KtyaAnXaBCHl09hDURUSrqYpg1cZvwDiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.26.1",
+        "@mux/playback-core": "0.30.1",
+        "media-chrome": "~4.11.1",
+        "player.style": "^0.1.9"
+      }
+    },
+    "node_modules/@mux/mux-player-react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.5.1.tgz",
+      "integrity": "sha512-tm32fSo9IBA/J8AD99bp64CyBkmv8jtsn4RhSHgNufvfWJUMBFJ7cfXgLsxiG/VdegpfBLRatMC5YiuZjoZ6yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "3.5.1",
+        "@mux/playback-core": "0.30.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mux/mux-video": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.26.1.tgz",
+      "integrity": "sha512-gkMdBAgNlB4+krANZHkQFzYWjWeNsJz69y1/hnPtmNQnpvW+O7oc71OffcZrbblyibSxWMQ6MQpYmBVjXlp6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/playback-core": "0.30.1",
+        "castable-video": "~1.1.10",
+        "custom-media-element": "~1.4.5",
+        "media-tracks": "~0.3.3"
+      }
+    },
+    "node_modules/@mux/playback-core": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.30.1.tgz",
+      "integrity": "sha512-rnO1NE9xHDyzbAkmE6ygJYcD7cyyMt7xXqWTykxlceaoSXLjUqgp42HDio7Lcidto4x/O4FIa7ztjV2aCBCXgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.6.6",
+        "mux-embed": "^5.8.3"
       }
     },
     "node_modules/@next/env": {
@@ -3385,6 +3469,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@svta/common-media-library": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@svta/common-media-library/-/common-media-library-0.12.4.tgz",
+      "integrity": "sha512-9EuOoaNmz7JrfGwjsrD9SxF9otU5TNMnbLu1yU4BeLK0W5cDxVXXR58Z89q9u2AnHjIctscjMTYdlqQ1gojTuw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -3545,6 +3635,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
+      "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vimeo/player": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.29.0.tgz",
+      "integrity": "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
       }
     },
     "node_modules/acorn": {
@@ -3901,6 +4007,54 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-normalize": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bcp-47-normalize/-/bcp-47-normalize-2.3.0.tgz",
+      "integrity": "sha512-8I/wfzqQvttUFz7HVJgIZ7+dj3vUaIyIxYXaTRP1YWoSDfzt6TUmxaKZeuXR62qBmYr+nvuWINFRl6pZ5DlN4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bcp-47": "^2.0.0",
+        "bcp-47-match": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4041,6 +4195,24 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/castable-video": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.10.tgz",
+      "integrity": "sha512-/T1I0A4VG769wTEZ8gWuy1Crn9saAfRTd1UYTb8xbOPlN78+zOi/1nU2dD5koNkfE5VWvgabkIqrGKmyNXOjSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.4.5"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.0.tgz",
+      "integrity": "sha512-84SEDLNHaAjykzlkqgKRq95hA3qnxrsTrwh4hTgBq6tfpINqajxz4bkz9q4orhUfpqDPQRgdCzYTF3bHcvTIlQ==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4137,6 +4309,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudflare-video-element": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/cloudflare-video-element/-/cloudflare-video-element-1.3.3.tgz",
+      "integrity": "sha512-qrHzwLmUhisoIuEoKc7iBbdzBNj2Pi7ThHslU/9U/6PY9DEvo4mh/U+w7OVuzXT9ks7ZXfARvDBfPAaMGF/hIg==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4145,6 +4323,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/codem-isoboxer": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.10.tgz",
+      "integrity": "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==",
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4261,11 +4445,45 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/custom-media-element": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
+      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dash-video-element": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/dash-video-element/-/dash-video-element-0.1.6.tgz",
+      "integrity": "sha512-4gHShaQjcFv6diX5EzB6qAdUGKlIUGGZY8J8yp2pQkWqR0jX4c6plYy0cFraN7mr0DZINe8ujDN1fssDYxJjcg==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.5",
+        "dashjs": "^5.0.3"
+      }
+    },
+    "node_modules/dashjs": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.0.3.tgz",
+      "integrity": "sha512-TXndNnCUjFjF2nYBxDVba+hWRpVkadkQ8flLp7kHkem+5+wZTfRShJCnVkPUosmjS0YPE9fVNLbYPJxHBeQZvA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@svta/common-media-library": "^0.12.4",
+        "bcp-47-match": "^2.0.3",
+        "bcp-47-normalize": "^2.3.0",
+        "codem-isoboxer": "0.3.10",
+        "fast-deep-equal": "3.1.3",
+        "html-entities": "^2.5.2",
+        "imsc": "^1.1.5",
+        "localforage": "^1.10.0",
+        "path-browserify": "^1.0.1",
+        "ua-parser-js": "^1.0.37"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -5599,6 +5817,39 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hls-video-element": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/hls-video-element/-/hls-video-element-1.5.6.tgz",
+      "integrity": "sha512-KPdvSR+oBJPiCVb+m6pd2mn3rJEjNbaK8pGhSkxFI2pmyvZIeTVQrPbEO9PT/juwXHwhvCoKJnNxAuFwJG9H5A==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.5",
+        "hls.js": "^1.6.5",
+        "media-tracks": "^0.3.3"
+      }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.7.tgz",
+      "integrity": "sha512-QW2fnwDGKGc9DwQUGLbmMOz8G48UZK7PVNJPcOUql1b8jubKx4/eMHNP5mGqr6tYlJNDG1g10Lx2U/qPzL6zwQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5607,6 +5858,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -5622,6 +5879,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imsc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
+      "integrity": "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "sax": "1.2.1"
       }
     },
     "node_modules/imurmurhash": {
@@ -5662,6 +5928,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -5822,6 +6112,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -6227,6 +6527,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -6241,6 +6550,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -6295,6 +6613,22 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/media-chrome": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.11.1.tgz",
+      "integrity": "sha512-+2niDc4qOwlpFAjwxg1OaizK/zKV6y7QqGm4nBFEVlSaG0ZBgOmfc4IXAPiirZqAlZGaFFUaMqCl1SpGU0/naA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/edge": "^1.2.1",
+        "ce-la-react": "^0.3.0"
+      }
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
+      "integrity": "sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6354,6 +6688,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mux-embed": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
+      "license": "MIT"
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -6382,6 +6722,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6741,6 +7087,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6833,6 +7185,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.1.9.tgz",
+      "integrity": "sha512-aFmIhHMrnAP8YliFYFMnRw+5AlHqBvnqWy4vHGo2kFxlC+XjmTXqgg62qSxlE8ubAY83c0ViEZGYglSJi6mGCA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.11.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7141,6 +7509,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-player": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-3.3.1.tgz",
+      "integrity": "sha512-wE/xLloneXZ1keelFCaNeIFVNUp4/7YoUjfHjwF945aQzsbDKiIB0LQuCchGL+la0Y1IybxnR0R6Cm3AiqInMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player-react": "^3.5.1",
+        "cloudflare-video-element": "^1.3.3",
+        "dash-video-element": "^0.1.6",
+        "hls-video-element": "^1.5.6",
+        "spotify-audio-element": "^1.0.2",
+        "tiktok-video-element": "^0.1.0",
+        "twitch-video-element": "^0.1.2",
+        "vimeo-video-element": "^1.5.3",
+        "wistia-video-element": "^1.3.3",
+        "youtube-video-element": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18 || ^19",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
@@ -7407,6 +7798,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -7589,6 +7986,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spotify-audio-element": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spotify-audio-element/-/spotify-audio-element-1.0.2.tgz",
+      "integrity": "sha512-YEovyyeJTJMzdSVqFw/Fx19e1gdcD4bmZZ/fWS0Ji58KTpvAT2rophgK87ocqpy6eJNSmIHikhgbRjGWumgZew==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -7893,6 +8296,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/super-media-element": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/super-media-element/-/super-media-element-1.4.2.tgz",
+      "integrity": "sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -8012,6 +8421,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiktok-video-element": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tiktok-video-element/-/tiktok-video-element-0.1.0.tgz",
+      "integrity": "sha512-PVWUlpDdQ/LPXi7x4/furfD7Xh1L72CgkGCaMsZBIjvxucMGm1DDPJdM9IhWBFfo6tuR4cYVO/v596r6GG/lvQ==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8077,6 +8492,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/twitch-video-element": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/twitch-video-element/-/twitch-video-element-0.1.2.tgz",
+      "integrity": "sha512-/up4KiWiTYiav+CUo+/DbV8JhP4COwEKSo8h1H/Zft/5NzZ/ZiIQ48h7erFKvwzalN0GfkEGGIfwIzAO0h7FHQ==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8186,6 +8607,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {
@@ -8319,6 +8766,24 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vimeo-video-element": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/vimeo-video-element/-/vimeo-video-element-1.5.3.tgz",
+      "integrity": "sha512-OQWyGS9nTouMqfRJyvmAm/n6IRhZ7x3EfPAef+Q+inGBeHa3SylDbtyeB/rEBd4B/T/lcYBW3rjaD9W2DRYkiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vimeo/player": "2.29.0"
+      }
+    },
+    "node_modules/weakmap-polyfill": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
+      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8411,6 +8876,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wistia-video-element": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wistia-video-element/-/wistia-video-element-1.3.3.tgz",
+      "integrity": "sha512-ZVC8HH8uV3mQGcSz10MACLDalao/0YdVverNN4GNFsOXiumfqSiZnRVc8WZEywgVckBkR7+yerQYESYPDzvTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "super-media-element": "~1.4.2"
       }
     },
     "node_modules/word-wrap": {
@@ -8522,6 +8996,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/youtube-video-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/youtube-video-element/-/youtube-video-element-1.6.1.tgz",
+      "integrity": "sha512-FDRgXlPxpe1bh6HlhL6GfJVcvVNaZKCcLEZ90X1G3Iu+z2g2cIhm2OWj9abPZq1Zqit6SY7Gwh13H9g7acoBnQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "fastapi-dev": "pip3 install -r requirements.txt && python3 -m uvicorn api.index:app --reload",
     "next-dev": "next dev",
     "dev": "concurrently \"npm run next-dev\" \"npm run fastapi-dev\"",
+    "dev:https": "next dev --experimental-https --experimental-https-key ./certificates/key.pem --experimental-https-cert ./certificates/cert.pem -p 3000 -H local.ami-works.com",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -31,6 +32,7 @@
     "concurrently": "^9.0.1",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.4",
+    "hls.js": "^1.6.7",
     "lucide-react": "^0.513.0",
     "next": "^15.3.3",
     "next-auth": "^5.0.0-beta.28",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",
     "@aws-sdk/client-s3": "^3.842.0",
+    "@aws-sdk/cloudfront-signer": "^3.858.0",
     "@aws-sdk/s3-request-presigner": "^3.842.0",
     "@prisma/client": "^6.9.0",
     "@prisma/extension-accelerate": "^2.0.1",
@@ -24,6 +25,7 @@
     "@types/react": "18.3.8",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.20",
+    "base64url": "^3.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "concurrently": "^9.0.1",
@@ -35,6 +37,7 @@
     "postcss": "^8.4.47",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-player": "^3.3.1",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "3.4.12",
     "tailwindcss-animate": "^1.0.7",

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -3,3 +3,11 @@ import { z } from "zod";
 export const videoSchema = z.object({
   filePath: z.string(),
 });
+
+export type Video = {
+  id: string;
+  filePath: string;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};


### PR DESCRIPTION
やったこと
- 署名付きcookieを作成するAPIを追加
- route53で独自ドメイン取得(アプリケーションとcloudfrontの代替ドメインを同じにして動画再生時にcookieをリクエストに含められるようにするため。)
- ACMでssl証明書発行(httpsで配信できるようにするため)
- 開発サーバーをmkcertを使用してhttps://local.ami.works:3000で起動するように
- Set-cookieのdomain属性に.ami-works.comを指定
- m3u8ファイルのリクエストにはcloudfrontのデフォルトにディストリビューションのドメインではなく、static.ami-works.comを指定するとcookieを送信できるようになった。